### PR TITLE
fixed misused sort funciton

### DIFF
--- a/src/Contexts/PositionProvider.jsx
+++ b/src/Contexts/PositionProvider.jsx
@@ -11,6 +11,7 @@ export default function PositionProvider({ children }) {
   );
   const [nearbyPOIs, setNearbyPOIs] = useState([]); // POIs stands for Points of Interest
 
+  // this useEffect fetches POIs data on OSM server
   useEffect(() => {
     getAllPoints(userLocation, 0.1, setNearbyPOIs);
     localStorage.setItem("userLocation", userLocation.toString());

--- a/src/scripts/osmUtilities.js
+++ b/src/scripts/osmUtilities.js
@@ -1,15 +1,15 @@
 export function getDistanceFromLatLonInKm(lat1, lon1, lat2, lon2) {
-  var R = 6371; // Radius of the earth in km
-  var dLat = deg2rad(lat2 - lat1); // deg2rad below
-  var dLon = deg2rad(lon2 - lon1);
-  var a =
+  const R = 6371; // Radius of the earth in km
+  const dLat = deg2rad(lat2 - lat1); // deg2rad below
+  const dLon = deg2rad(lon2 - lon1);
+  const a =
     Math.sin(dLat / 2) * Math.sin(dLat / 2) +
     Math.cos(deg2rad(lat1)) *
       Math.cos(deg2rad(lat2)) *
       Math.sin(dLon / 2) *
       Math.sin(dLon / 2);
-  var c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
-  var d = R * c; // Distance in km
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  let d = R * c; // Distance in km
   return d.toFixed(2); //to fixed returns only 2 decimal places.
 }
 
@@ -62,7 +62,7 @@ export async function getAllPoints(location, radius, setterFunction) {
             ),
           }))
           .sort((pointA, pointB) =>
-            pointA.distanceKm - pointB.distanceKm > 0 ? true : false
+            pointA.distanceKm - pointB.distanceKm
           )
       );
     });


### PR DESCRIPTION
The sort function was behaving wrong in chrome because it returned true/false instead of returning a number, as it should have. 