### PR TITLE
Bugfix search this area over pop ups

### DIFF
--- a/src/components/SearchThisArea.jsx
+++ b/src/components/SearchThisArea.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { usePosition } from "../Contexts/PositionProvider";
 import { usePOIs } from "../Contexts/PointsOfInterestProvider";
 import { getNewPoints } from "../scripts/osmUtilities";
@@ -11,10 +11,27 @@ export default function SearchThisArea() {
   const { userLocation, mapPosition } = usePosition();
   const { setAreaPOIs, userFilters } = usePOIs();
   const [requestStatus, setRequestStatus] = useState("ready to fetch");
-  const [isHidden, setIsHidden]=useState(false);
+  const buttonRef = useRef(null);
 
-  map.on("popupopen",()=>setIsHidden(true))
-  map.on("popupclose",()=>setIsHidden(false))
+  useEffect(() => {
+    const button = buttonRef.current;
+
+    const handlePopupOpen = () => {
+      button.classList.add("hidden");
+    };
+
+    const handlePopupClose = () => {
+      button.classList.remove("hidden");
+    };
+
+    map.on("popupopen", handlePopupOpen);
+    map.on("popupclose", handlePopupClose);
+
+    return () => {
+      map.off("popupopen", handlePopupOpen);
+      map.off("popupclose", handlePopupClose);
+    };
+  }, [map]);
 
   useEffect(() => {
     if (requestStatus === "data received") {
@@ -36,7 +53,8 @@ export default function SearchThisArea() {
     <div id="search-this-area-button-container">
       <button
         id="search-this-area-button"
-        className={`button-feedback ${requestStatus !== "ready to fetch" ? "disabled" : ""} ${isHidden?"hidden":""}`}
+        ref={buttonRef}
+        className={`button-feedback ${requestStatus !== "ready to fetch" ? "disabled" : ""}`}
         onClick={handleSearch}
         disabled={requestStatus !== "ready to fetch"}
       >

--- a/src/components/SearchThisArea.jsx
+++ b/src/components/SearchThisArea.jsx
@@ -3,12 +3,18 @@ import { usePosition } from "../Contexts/PositionProvider";
 import { usePOIs } from "../Contexts/PointsOfInterestProvider";
 import { getNewPoints } from "../scripts/osmUtilities";
 import "../styles/searchThisAreaButton.css";
+import { useMap } from "react-leaflet";
 
 // Needed for the user to be able to research POIs somewhere else without loading all the world's POIs in memory
 export default function SearchThisArea() {
+  const map = useMap();
   const { userLocation, mapPosition } = usePosition();
   const { setAreaPOIs, userFilters } = usePOIs();
   const [requestStatus, setRequestStatus] = useState("ready to fetch");
+  const [isHidden, setIsHidden]=useState(false);
+
+  map.on("popupopen",()=>setIsHidden(true))
+  map.on("popupclose",()=>setIsHidden(false))
 
   useEffect(() => {
     if (requestStatus === "data received") {
@@ -30,7 +36,7 @@ export default function SearchThisArea() {
     <div id="search-this-area-button-container">
       <button
         id="search-this-area-button"
-        className={`button-feedback ${requestStatus !== "ready to fetch" ? "disabled" : ""}`}
+        className={`button-feedback ${requestStatus !== "ready to fetch" ? "disabled" : ""} ${isHidden?"hidden":""}`}
         onClick={handleSearch}
         disabled={requestStatus !== "ready to fetch"}
       >

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -43,9 +43,8 @@ export default function Map() {
             attribution={mapProviders[mapSelecter.providerId].attribution}
             url={mapProviders[mapSelecter.providerId].tilesUrl}
           />
-          <Pane name="customPane" style={{ zIndex: 200 }}>
-          <SearchThisArea />
-          </Pane>
+
+            <SearchThisArea />
 
           <Markers />
 

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { MapContainer, TileLayer } from "react-leaflet";
+import { Pane, MapContainer, TileLayer } from "react-leaflet";
 import PositionProvider from "../Contexts/PositionProvider";
 import PointsOfInterestProvider from "../Contexts/PointsOfInterestProvider";
 import UserMarker from "../components/UserMarker";
@@ -34,7 +34,7 @@ export default function Map() {
           setMapSelecter={setMapSelecter}
         />
         <RecenterButton />
-        <SearchThisArea />
+
         <FilterBar listState={{ listIsDisplayed, setListIsDisplayed }} />
 
         <Walter />
@@ -43,6 +43,10 @@ export default function Map() {
             attribution={mapProviders[mapSelecter.providerId].attribution}
             url={mapProviders[mapSelecter.providerId].tilesUrl}
           />
+          <Pane name="customPane" style={{ zIndex: 200 }}>
+          <SearchThisArea />
+          </Pane>
+
           <Markers />
 
           <UserMarker />

--- a/src/pages/Map.jsx
+++ b/src/pages/Map.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Pane, MapContainer, TileLayer } from "react-leaflet";
+import { MapContainer, TileLayer } from "react-leaflet";
 import PositionProvider from "../Contexts/PositionProvider";
 import PointsOfInterestProvider from "../Contexts/PointsOfInterestProvider";
 import UserMarker from "../components/UserMarker";

--- a/src/styles/searchThisAreaButton.css
+++ b/src/styles/searchThisAreaButton.css
@@ -19,7 +19,7 @@
 }
 
 #search-this-area-button.hidden {
-  transform: translate(-50%, -100px);
+  transform: translateY(-100px);
 }
 
 #search-this-area-button.disabled {

--- a/src/styles/searchThisAreaButton.css
+++ b/src/styles/searchThisAreaButton.css
@@ -1,5 +1,5 @@
 #search-this-area-button-container {
-  z-index: 100;
+  z-index: 400;
   position: absolute;
   top: 60px;
   left: 50%;

--- a/src/styles/searchThisAreaButton.css
+++ b/src/styles/searchThisAreaButton.css
@@ -1,5 +1,5 @@
 #search-this-area-button-container {
-  z-index: 400;
+  z-index: 1000;
   position: absolute;
   top: 60px;
   left: 50%;

--- a/src/styles/searchThisAreaButton.css
+++ b/src/styles/searchThisAreaButton.css
@@ -1,5 +1,5 @@
 #search-this-area-button-container {
-  z-index: 1000;
+  z-index: 100;
   position: absolute;
   top: 60px;
   left: 50%;


### PR DESCRIPTION
As mentionned by @MrLootman the search this area button could be over the popups on small screens, thus i created two event listeners that listen for pop-ups opening and closing and add or remove the hidden class to the button.

Fisrt commit was an error, as fixing it with z-index inside a pane didn't let me fix the button relative to the screen, but only to the map. 