### PR TITLE
FEATURE added a link that opens Gmaps in the popups

### DIFF
--- a/src/components/UI/ExternalLink/ExternalLink.css
+++ b/src/components/UI/ExternalLink/ExternalLink.css
@@ -6,6 +6,7 @@ a.external-link {
   display: inline-flex;
   gap: 0.2rem;
   align-items: center;
+  font-size: var(--font-size);
 
   & img.external-link-icon {
     height: var(--font-size);

--- a/src/components/UI/ExternalLink/ExternalLink.props.ts
+++ b/src/components/UI/ExternalLink/ExternalLink.props.ts
@@ -1,4 +1,5 @@
 export default interface ExternalLinkProps {
   href: string;
   children: React.ReactNode;
+  className?: string;
 }

--- a/src/components/UI/ExternalLink/ExternalLink.tsx
+++ b/src/components/UI/ExternalLink/ExternalLink.tsx
@@ -1,9 +1,9 @@
 import ExternalLinkProps from './ExternalLink.props';
 import './ExternalLink.css';
 
-export default function ExternalLink({ href, children }: ExternalLinkProps) {
+export default function ExternalLink({ href, children, className }: ExternalLinkProps) {
   return (
-    <a className="external-link" href={href} target="_blank">
+    <a className={`external-link ${className}`} href={href} target="_blank">
       {children}
       <img className="external-link-icon" src="/icons/external-link.svg" alt=""></img>
     </a>

--- a/src/components/map_UI/POIDetails/POIDetails.tsx
+++ b/src/components/map_UI/POIDetails/POIDetails.tsx
@@ -1,6 +1,7 @@
 import { memo } from 'react';
-import './POIDetails.css';
 import { Point } from '@/Contexts/contexts.types';
+import './POIDetails.css';
+
 // Official doc for POI tags : https://wiki.openstreetmap.org/wiki/Tag:amenity%3Dtoilets
 
 function POIDetailsComponent({ point }: { point: Point }) {

--- a/src/components/map_components/CustomMarker/CustomMarker.tsx
+++ b/src/components/map_components/CustomMarker/CustomMarker.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { Marker, Popup } from 'react-leaflet';
 import { faucetIcon, toiletIcon, foodIcon } from '@/utilities/icons';
 import POIDetails from '../../map_UI/POIDetails/POIDetails';
+import ExternalLink from '@/components/UI/ExternalLink/ExternalLink';
 import CustomMarkerProps from './CustomMarker.props';
 import './LeafletPopup.css';
 
@@ -24,6 +25,11 @@ function CustomMarkerComponent({ point, onMarkerClick }: CustomMarkerProps) {
     >
       <Popup keepInView={false} autoPan={false} className={`${point.id}`}>
         <POIDetails point={point} />
+          <ExternalLink className="itinerary_container"
+            href={`https://www.google.com/maps/dir/?api=1&destination=${point.lat},${point.lon}&travelmode=walking`}
+          >
+            Get itinerary
+          </ExternalLink>
       </Popup>
     </Marker>
   );

--- a/src/components/map_components/CustomMarker/LeafletPopup.css
+++ b/src/components/map_components/CustomMarker/LeafletPopup.css
@@ -1,7 +1,13 @@
 .leaflet-popup-content {
-  padding: 0.75rem 0;
+  padding-top: 0.75rem;
   min-width: 200px;
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
+
+  & .itinerary_container {
+    display:flex;
+    justify-content: center;
+    align-items: start;
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/Acetoshi/WalterWater/issues/82

ExternalLink Component:
-Updated the CSS to include a font-size property.
-Added an optional className prop to the ExternalLinkProps interface.
-Modified the ExternalLink component to accept and apply the className prop.

POIDetails Component:
-Adjusted import statements formatting in POIDetails.tsx.

CustomMarker Component:
-Added an import for the ExternalLink component.
-Included an ExternalLink in the popup, linking to Google Maps for walking directions to the marker's location.
-Updated the CSS for the popup to style the new itinerary link.

LeafletPopup CSS:
-Adjusted padding and added styles for the new itinerary link container.